### PR TITLE
TryInto<Write> impls on execute obj builders and adds writes manipulation on FirestoreTransaction.

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -68,7 +68,7 @@ pub use transaction_models::*;
 
 /// Internal module for transaction operations.
 mod transaction_ops;
-use transaction_ops::*;
+pub(crate) use transaction_ops::*;
 
 /// Module for session-specific parameters (e.g., consistency, caching).
 mod session_params;

--- a/src/db/transaction.rs
+++ b/src/db/transaction.rs
@@ -333,3 +333,13 @@ impl FirestoreDb {
         retry_result
     }
 }
+
+impl<'a> FirestoreTransaction<'a> {
+    pub fn set_writes(&mut self, writes: Vec<gcloud_sdk::google::firestore::v1::Write>) {
+        self.writes = writes;
+    }
+
+    pub fn add_write(&mut self, write: gcloud_sdk::google::firestore::v1::Write) {
+        self.writes.push(write);
+    }
+}


### PR DESCRIPTION
Problem: When building relatively flexible and complex abstractions for db transactions in particular, often you want to do something like: "Hey, just consider these write commands,  just data - no borrows, fancy references etc. And then later we'll commit/rollback." 

And you may also want a very dumb data layer: "I'm gonna pass you a write sink, and you will just write to it and get back an async result. You don't know or care whether you are in a transaction or not."

However, this is tricky with the existing APIs for `firestore-rs`. The fluent builders are super nice to work with, and the `tracing` integration is great.  but with them you are stuck with references to the db, and there's no version of a "`OwnedTransaction`" that owns the db. That makes a setup like the following tricky to implement:

```rust
/// A trait representing a write sink that can consume write commands and may fail.
#[async_trait::async_trait]
pub trait DbExecutorWriteSink {
    /// The type of write command this sink accepts.
    type WriteCmd;

    /// The error type that can be returned on failure.
    type Err;

    /// Perform the write operation. Implementations may batch, execute immediately, or
    /// buffer writes, etc. The caller doesn't know or care.
    async fn write(&mut self, cmd: Self::WriteCmd) -> Result<(), Self::Err>;
}

/// A trait for an executor that supports both transactional and non-transactional reads/writes.
pub trait DbExecutor {
    /// An opaque type used for reads. Typically, something like a reference to a DB or service.
    type ReadSource;

    /// A write sink used for non-transactional writes (executed immediately).
    type WriteSink: DbExecutorWriteSink<Err = Self::Err> + Send;

    /// A write sink used for transactional writes (buffered and committed later).
    type TxnWriteSink: DbExecutorWriteSink<Err = Self::Err> + Send;

    /// The common error type used across read/write operations.
    type Err;

    /// Get a reader object to use for read operations.
    fn reader(&self) -> Self::ReadSource;

    /// Get a non-transactional writer to use for immediate writes.
    fn writer(&self) -> Self::WriteSink;

    /// Run a transactional block with access to a reader and a transactional write sink.
    ///
    /// The passed closure receives owned read and write handles and must return them,
    /// along with a result, so the executor can finalize the transaction (e.g., commit or rollback).
    async fn run_tx<T, E, F>(&self, f: F) -> Result<T, E>
    where
        F: Fn(
            Self::ReadSource,
            Self::TxnWriteSink,
        ) -> BoxFuture<'static, Result<T, E>>,
        E: From<Self::Err>;
}
```

There's probably a way to do this kind of thing with GATs and HRTBs and returning the `TxnWriteSink` in the output of the future... but things start getting complex quickly and it'd be nice to have the dead simple option.

So we just implement `TryInto<gcloud_sdk::google::firestore::v1::Write` on our execute object builds, and add set/add writes to the `FirestoreTransaction` struct. (Could do document ones too but I'm not using them right now).

We've duplicated a bit of logic with creating delete and update operations, but since that logic was already duplicated in the library it likely doesn't change often and it's pretty straightforward.

